### PR TITLE
remove unneeded check from getUrl + isCname

### DIFF
--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -567,8 +567,7 @@ class AliOssAdapter extends AbstractAdapter
      */
     public function getUrl( $path )
     {
-        if (!$this->has($path)) throw new FileNotFoundException($filePath.' not found');
-        return ( $this->ssl ? 'https://' : 'http://' ) . ( $this->isCname ? ( $this->cdnDomain == '' ? $this->endpoint : $this->cdnDomain ) : $this->bucket . '.' . $this->endPoint ) . '/' . ltrim($path, '/');
+        return ( $this->ssl ? 'https://' : 'http://' ) . ( $this->cdnDomain == '' ?  $this->bucket . '.' . $this->endPoint : $this->cdnDomain ) . '/' . ltrim($path, '/');
     }
 
     /**


### PR DESCRIPTION
- Removed unneeded file exists check from `getUrl()` function
- CdnDomain no longer depends on isCname config option (that option doesn't work properly) 