### PR TITLE
增加使用签名URL进行临时授权,支持生成私有bucket访问地址

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-    "name": "jacobcyl/ali-oss-storage",
+    "name": "SummerGeorge/ali-oss-storage",
     "description": "aliyun oss filesystem storage for laravel 5+",
     "keywords": ["aliyun", "oss", "laravel", "filesystems", "storage"],
-    "homepage": "http://jacobcyl.github.io/Aliyun-oss-storage/",
+    "homepage": "http://SummerGeorge.github.io/Aliyun-oss-storage/",
     "license": "MIT",
     "authors": [
         {
-            "name": "jacobcyl",
+            "name": "SummerGeorge",
             "email": "cyl.jacob@gmail.com"
         }
     ],
@@ -15,13 +15,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Jacobcyl\\AliOSS\\": "src/"
+            "SummerGeorge\\AliOSS\\": "src/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "Jacobcyl\\AliOSS\\AliOssServiceProvider"
+                "SummerGeorge\\AliOSS\\AliOssServiceProvider"
             ]
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-    "name": "SummerGeorge/ali-oss-storage",
+    "name": "jacobcyl/ali-oss-storage",
     "description": "aliyun oss filesystem storage for laravel 5+",
     "keywords": ["aliyun", "oss", "laravel", "filesystems", "storage"],
-    "homepage": "http://SummerGeorge.github.io/Aliyun-oss-storage/",
+    "homepage": "http://jacobcyl.github.io/Aliyun-oss-storage/",
     "license": "MIT",
     "authors": [
         {
-            "name": "SummerGeorge",
+            "name": "jacobcyl",
             "email": "cyl.jacob@gmail.com"
         }
     ],
@@ -15,13 +15,13 @@
     },
     "autoload": {
         "psr-4": {
-            "SummerGeorge\\AliOSS\\": "src/"
+            "Jacobcyl\\AliOSS\\": "src/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "SummerGeorge\\AliOSS\\AliOssServiceProvider"
+                "Jacobcyl\\AliOSS\\AliOssServiceProvider"
             ]
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-    "name": "jacobcyl/ali-oss-storage",
+    "name": "summergeorgef/ali-oss-storage",
     "description": "aliyun oss filesystem storage for laravel 5+",
     "keywords": ["aliyun", "oss", "laravel", "filesystems", "storage"],
-    "homepage": "http://jacobcyl.github.io/Aliyun-oss-storage/",
+    "homepage": "https://github.com/summergeorge/Aliyun-oss-storage",
     "license": "MIT",
     "authors": [
         {
-            "name": "jacobcyl",
-            "email": "cyl.jacob@gmail.com"
+            "name": "summergeorge",
+            "email": "qihao201net@126.com"
         }
     ],
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "summergeorgef/ali-oss-storage",
+    "name": "summergeorge/ali-oss-storage",
     "description": "aliyun oss filesystem storage for laravel 5+",
     "keywords": ["aliyun", "oss", "laravel", "filesystems", "storage"],
     "homepage": "https://github.com/summergeorge/Aliyun-oss-storage",

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,16 @@
-# Aliyun-oss-storage for Laravel 5+
+<h1 align="center">
+ Aliyun-oss-storage for Laravel 5+
+</h1>
+
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/?branch=master)
+[![Build Status](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/badges/build.png?b=master)](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/build-status/master)
+[![Latest Stable Version](https://poser.pugx.org/summergeorge/ali-oss-storage/v/stable)](https://packagist.org/packages/summergeorge/ali-oss-storage)
+[![Total Downloads](https://poser.pugx.org/summergeorge/ali-oss-storage/downloads)](https://packagist.org/packages/summergeorge/ali-oss-storage)
+[![Latest Unstable Version](https://poser.pugx.org/summergeorge/ali-oss-storage/v/unstable)](https://packagist.org/packages/summergeorge/ali-oss-storage)
+[![License](https://poser.pugx.org/summergeorge/ali-oss-storage/license)](https://packagist.org/packages/summergeorge/ali-oss-storage)
+
+----
+
 Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just like laravel Storage as usual.    
 借鉴了一些优秀的代码，综合各方，同时做了更多优化，将会添加更多完善的接口和插件，打造Laravel最好的OSS Storage扩展
 ## Inspired By

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
-### 如果本项目对您有帮助且愿意花时间一起维护，欢迎提交PR，我将每个月做一次PR合并。
-### 如果您想和我一起维护，欢迎发邮件给我，我将把您加为项目协作者。
+> 如果本项目对您有帮助且愿意花时间一起维护，欢迎提交PR，我将每个月做一次PR合并。
+
+> 如果您想和我一起维护，欢迎发邮件给我，我将把您加为项目协作者。
 # Aliyun-oss-storage for Laravel 5+
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/badges/build.png?b=master)](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/build-status/master)

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,3 @@
-# 声明：
-之所以启用这个项目，是因为github上的[https://github.com/jacobcyl/Aliyun-oss-storage](https://github.com/jacobcyl/Aliyun-oss-storage)这个作者好像不怎么维护了。
-
-fork一个自己用的项目
-
 # Aliyun-oss-storage for Laravel 5+
 Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just like laravel Storage as usual.    
 借鉴了一些优秀的代码，综合各方，同时做了更多优化，将会添加更多完善的接口和插件，打造Laravel最好的OSS Storage扩展
@@ -17,16 +12,16 @@ Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just
 ##Installation
 In order to install AliOSS-storage, just add
 
-    "SummerGeorge/ali-oss-storage": "^2.1"
+    "jacobcyl/ali-oss-storage": "^2.1"
 
 to your composer.json. Then run `composer install` or `composer update`.  
 Or you can simply run below command to install:
 
-    "composer require SummerGeorge/ali-oss-storage:^2.1"
+    "composer require jacobcyl/ali-oss-storage:^2.1"
     
 Then in your `config/app.php` add this line to providers array:
 ```php
-SummerGeorge\AliOSS\AliOssServiceProvider::class,
+Jacobcyl\AliOSS\AliOssServiceProvider::class,
 ```
 ## Configuration
 Add the following in app/filesystems.php:

--- a/readme.md
+++ b/readme.md
@@ -4,20 +4,24 @@ Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just
 ## Inspired By
 - [thephpleague/flysystem-aws-s3-v2](https://github.com/thephpleague/flysystem-aws-s3-v2)
 - [apollopy/flysystem-aliyun-oss](https://github.com/apollopy/flysystem-aliyun-oss) 
+- [jacobcyl/Aliyun-oss-storage](https://github.com/jacobcyl/Aliyun-oss-storage) 
 
 ## Require
 - Laravel 5+
 - cURL extension
 
-##Installation
+更新：2019-02-15
+之前 fork 的 [jacobcyl/Aliyun-oss-storage](https://github.com/jacobcyl/Aliyun-oss-storage) ，自2.1.1版本开始，增加新功能，更改 composer 包名称为：`summergeorge/ali-oss-storage`
+
+## Installation 
 In order to install AliOSS-storage, just add
 
-    "jacobcyl/ali-oss-storage": "^2.1"
+    "summergeorge/ali-oss-storage": "^2.1"
 
 to your composer.json. Then run `composer install` or `composer update`.  
 Or you can simply run below command to install:
 
-    "composer require jacobcyl/ali-oss-storage:^2.1"
+    "composer require summergeorge/ali-oss-storage:^2.1"
     
 Then in your `config/app.php` add this line to providers array:
 ```php
@@ -96,7 +100,12 @@ Storage::deleteDirectory($directory); // Recursively delete a directory.It will 
 Storage::putRemoteFile('target/path/to/file/jacob.jpg', 'http://example.com/jacob.jpg'); //upload remote file to storage by remote url
 // new function for v2.0.1 version
 Storage::url('path/to/img.jpg') // get the file url
+// new function for v2.1.1 version
 Storage::signUrl('path/to/img.jpg',$timeout) // get the file url with signature,default timeout = 600
+
+// new function for v2.1.2 version
+// 阿里云 oss 帮助文档：https://help.aliyun.com/document_detail/44688.html?spm=a2c4g.11186623.6.1199.40572e934MoHWu
+Storage::getProcessUrl('path/to/img.jpg','resize', ['m' => 'fixed','h' => '100','w' => '100']) // picture processing，处理图片，支持 oss 图片处理的功能
 ```
 
 ## Documentation

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,6 @@ Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just
 - Laravel 5+
 - cURL extension
 
-更新：2019-02-15
 之前 fork 的 [jacobcyl/Aliyun-oss-storage](https://github.com/jacobcyl/Aliyun-oss-storage) ，自2.1.1版本开始，增加新功能，更改 composer 包名称为：`summergeorge/ali-oss-storage`
 
 ## Installation 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,8 @@
+# 声明：
+之所以启用这个项目，是因为github上的[https://github.com/jacobcyl/Aliyun-oss-storage](https://github.com/jacobcyl/Aliyun-oss-storage)这个作者好像不怎么维护了。
+
+fork一个自己用的项目
+
 # Aliyun-oss-storage for Laravel 5+
 Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just like laravel Storage as usual.    
 借鉴了一些优秀的代码，综合各方，同时做了更多优化，将会添加更多完善的接口和插件，打造Laravel最好的OSS Storage扩展
@@ -12,16 +17,16 @@ Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just
 ##Installation
 In order to install AliOSS-storage, just add
 
-    "jacobcyl/ali-oss-storage": "^2.1"
+    "SummerGeorge/ali-oss-storage": "^2.1"
 
 to your composer.json. Then run `composer install` or `composer update`.  
 Or you can simply run below command to install:
 
-    "composer require jacobcyl/ali-oss-storage:^2.1"
+    "composer require SummerGeorge/ali-oss-storage:^2.1"
     
 Then in your `config/app.php` add this line to providers array:
 ```php
-Jacobcyl\AliOSS\AliOssServiceProvider::class,
+SummerGeorge\AliOSS\AliOssServiceProvider::class,
 ```
 ## Configuration
 Add the following in app/filesystems.php:

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ Storage::signUrl('path/to/img.jpg',$timeout) // get the file url with signature,
 
 // new function for v2.1.2 version
 // 阿里云 oss 帮助文档：https://help.aliyun.com/document_detail/44688.html?spm=a2c4g.11186623.6.1199.40572e934MoHWu
+// getProcessUrl(图片在 oss 中的路径,操作名称（例如：resize）,参数（key => value 形式的数组）);
 Storage::getProcessUrl('path/to/img.jpg','resize', ['m' => 'fixed','h' => '100','w' => '100']) // picture processing，处理图片，支持 oss 图片处理的功能
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
+### 如果本项目对您有帮助且愿意花时间一起维护，欢迎提交PR，我将每个月做一次PR合并。
+### 如果您想和我一起维护，欢迎发邮件给我，我将把您加为项目协作者。
 # Aliyun-oss-storage for Laravel 5+
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/badges/build.png?b=master)](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/build-status/master)
@@ -11,7 +13,7 @@
 Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just like laravel Storage as usual.    
 借鉴了一些优秀的代码，综合各方，同时做了更多优化，将会添加更多完善的接口和插件，打造Laravel最好的OSS Storage扩展
 
-#### 如果您对本项目对您有帮助且愿意花时间一起维护，欢迎通过Issues给我留言，我将把您添加为协作者。
+
 ## Inspired By
 - [thephpleague/flysystem-aws-s3-v2](https://github.com/thephpleague/flysystem-aws-s3-v2)
 - [apollopy/flysystem-aliyun-oss](https://github.com/apollopy/flysystem-aliyun-oss) 
@@ -48,7 +50,7 @@ Add the following in app/filesystems.php:
             'access_key'    => '<Your Aliyun OSS AccessKeySecret>',
             'bucket'        => '<OSS bucket name>',
             'endpoint'      => '<the endpoint of OSS, E.g: oss-cn-hangzhou.aliyuncs.com | custom domain, E.g:img.abc.com>', // OSS 外网节点或自定义外部域名
-            //'endpoint_internal' => '<internal endpoint [OSS内网节点] 如：oss-cn-shenzhen-internal.aliyuncs.com>', // v2.0.4 新增配置属性，如果为空，则默认使用 endpoint 配置(由于内网上传有点小问题未解决，请大家暂时不要使用内网节点上传，正在与阿里技术沟通中)
+            'endpoint_internal' => '<internal endpoint [OSS内网节点] 如：oss-cn-shenzhen-internal.aliyuncs.com>', // v2.2.1 新增配置属性，如果为空，则默认使用 endpoint 配置。
             'cdnDomain'     => '<CDN domain, cdn域名>', // 如果isCName为true, getUrl会判断cdnDomain是否设定来决定返回的url，如果cdnDomain未设置，则使用endpoint来生成url，否则使用cdn
             'ssl'           => <true|false> // true to use 'https://' and false to use 'http://'. default is false,
             'isCName'       => <true|false> // 是否使用自定义域名,true: 则Storage.url()会使用自定义的cdn或域名生成文件url， false: 则使用外部节点生成url

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@
 
 Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just like laravel Storage as usual.    
 借鉴了一些优秀的代码，综合各方，同时做了更多优化，将会添加更多完善的接口和插件，打造Laravel最好的OSS Storage扩展
+
+#### 如果您对本项目对您有帮助且愿意花时间一起维护，欢迎通过Issues给我留言，我将把您添加为协作者。
 ## Inspired By
 - [thephpleague/flysystem-aws-s3-v2](https://github.com/thephpleague/flysystem-aws-s3-v2)
 - [apollopy/flysystem-aliyun-oss](https://github.com/apollopy/flysystem-aliyun-oss) 
@@ -109,7 +111,9 @@ Storage::putRemoteFile('target/path/to/file/jacob.jpg', 'http://example.com/jaco
 // new function for v2.0.1 version
 Storage::url('path/to/img.jpg') // get the file url
 // new function for v2.1.1 version
-Storage::signUrl('path/to/img.jpg',$timeout) // get the file url with signature,default timeout = 600
+Storage::signUrl('path/to/img.jpg',$timeout) //（请使用新的temporaryUrl方法） get the file url with signature,default timeout = 600
+// new function for v2.1.4 version
+Storage::temporaryUrl('path/to/img.jpg',$timeout) // get the file url with signature,default timeout = 600
 
 // new function for v2.1.2 version
 // 阿里云 oss 帮助文档：https://help.aliyun.com/document_detail/44688.html?spm=a2c4g.11186623.6.1199.40572e934MoHWu

--- a/readme.md
+++ b/readme.md
@@ -28,12 +28,12 @@ Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just
 ## Installation 
 In order to install AliOSS-storage, just add
 
-    "summergeorge/ali-oss-storage": "^2.1"
+    "summergeorge/ali-oss-storage": "^2.2"
 
 to your composer.json. Then run `composer install` or `composer update`.  
 Or you can simply run below command to install:
 
-    "composer require summergeorge/ali-oss-storage:^2.1"
+    "composer require summergeorge/ali-oss-storage:^2.2"
     
 Then in your `config/app.php` add this line to providers array:
 ```php

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,4 @@
-<h1 align="center">
- Aliyun-oss-storage for Laravel 5+
-</h1>
-
+# Aliyun-oss-storage for Laravel 5+
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/badges/build.png?b=master)](https://scrutinizer-ci.com/g/summergeorge/Aliyun-oss-storage/build-status/master)
 [![Latest Stable Version](https://poser.pugx.org/summergeorge/ali-oss-storage/v/stable)](https://packagist.org/packages/summergeorge/ali-oss-storage)
@@ -9,7 +6,7 @@
 [![Latest Unstable Version](https://poser.pugx.org/summergeorge/ali-oss-storage/v/unstable)](https://packagist.org/packages/summergeorge/ali-oss-storage)
 [![License](https://poser.pugx.org/summergeorge/ali-oss-storage/license)](https://packagist.org/packages/summergeorge/ali-oss-storage)
 
-----
+---
 
 Aliyun oss filesystem storage adapter for laravel 5. You can use Aliyun OSS just like laravel Storage as usual.    
 借鉴了一些优秀的代码，综合各方，同时做了更多优化，将会添加更多完善的接口和插件，打造Laravel最好的OSS Storage扩展

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ Storage::deleteDirectory($directory); // Recursively delete a directory.It will 
 Storage::putRemoteFile('target/path/to/file/jacob.jpg', 'http://example.com/jacob.jpg'); //upload remote file to storage by remote url
 // new function for v2.0.1 version
 Storage::url('path/to/img.jpg') // get the file url
+Storage::signUrl('path/to/img.jpg',$timeout) // get the file url with signature,default timeout = 600
 ```
 
 ## Documentation

--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -448,12 +448,16 @@ class AliOssAdapter extends AbstractAdapter
     public function readStream($path)
     {
         $result = $this->readObject($path);
-        $result['stream'] = $result['raw_contents'];
+        if (is_resource($result['raw_contents'])) {
+            $result['stream'] = $result['raw_contents'];
+            $result['raw_contents']->detachStream();
+        } else {
+            $result['stream'] = fopen('php://temp', 'r+');
+            fwrite($result['stream'], $result['raw_contents']);
+        }
         rewind($result['stream']);
         // Ensure the EntityBody object destruction doesn't close the stream
-        $result['raw_contents']->detachStream();
         unset($result['raw_contents']);
-
         return $result;
     }
 

--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -7,6 +7,7 @@
 
 namespace Jacobcyl\AliOSS;
 
+use Illuminate\Support\Arr;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
@@ -573,8 +574,8 @@ class AliOssAdapter extends AbstractAdapter
         if (!$this->has($path)) throw new FileNotFoundException($path.' not found');
         return ( $this->ssl ? 'https://' : 'http://' ) . ( $this->isCname ? ( $this->cdnDomain == '' ? $this->endPoint : $this->cdnDomain ) : $this->bucket . '.' . $this->endPoint ) . '/' . ltrim($path, '/');
     }
-    
-    
+
+
     /**
      * @param $path
      * @param $expire
@@ -583,7 +584,7 @@ class AliOssAdapter extends AbstractAdapter
      * @throws FileNotFoundException
      * @throws OssException
      */
-    public function getTemporaryUrl($path, $expire, $options) {
+    public function getTemporaryUrl($path, $expire = 600, $options) {
         if (!$this->has($path))
             throw new FileNotFoundException($path.' not found');
         $method = OssClient::OSS_HTTP_GET;
@@ -594,12 +595,12 @@ class AliOssAdapter extends AbstractAdapter
             ->signUrl(
                 $this->getBucket(),
                 $path,
-                now()->diffInSeconds($expire),
+                $expire,
                 $method,
                 $options
             );
     }
-    
+
 
     /**
      * The the ACL visibility.

--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -660,7 +660,7 @@ class AliOssAdapter extends AbstractAdapter
             $options = array_merge($options, $this->getOptionsFromConfig($config));
         }
 
-        return array(OssClient::OSS_HEADERS => $options);
+        return $options;
     }
 
     /**

--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -7,7 +7,6 @@
 
 namespace Jacobcyl\AliOSS;
 
-use Dingo\Api\Contract\Transformer\Adapter;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\AdapterInterface;
 use League\Flysystem\Config;
@@ -15,7 +14,7 @@ use League\Flysystem\Util;
 use OSS\Core\OssException;
 use OSS\OssClient;
 use Log;
-use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class AliOssAdapter extends AbstractAdapter
 {
@@ -67,7 +66,7 @@ class AliOssAdapter extends AbstractAdapter
     protected $bucket;
 
     protected $endPoint;
-    
+
     protected $cdnDomain;
 
     protected $ssl;
@@ -549,7 +548,7 @@ class AliOssAdapter extends AbstractAdapter
             $this->logErr(__FUNCTION__, $e);
             return false;
         }
-        
+
         if ($acl == OssClient::OSS_ACL_TYPE_PUBLIC_READ ){
             $res['visibility'] = AdapterInterface::VISIBILITY_PUBLIC;
         }else{
@@ -567,7 +566,7 @@ class AliOssAdapter extends AbstractAdapter
      */
     public function getUrl( $path )
     {
-        if (!$this->has($path)) throw new FileNotFoundException($filePath.' not found');
+        if (!$this->has($path)) throw new FileNotFoundException($path.' not found');
         return ( $this->ssl ? 'https://' : 'http://' ) . ( $this->isCname ? ( $this->cdnDomain == '' ? $this->endPoint : $this->cdnDomain ) : $this->bucket . '.' . $this->endPoint ) . '/' . ltrim($path, '/');
     }
 
@@ -608,7 +607,7 @@ class AliOssAdapter extends AbstractAdapter
 
             return $result;
         }
-        
+
         $result = array_merge($result, Util::map($object, static::$resultMap), ['type' => 'file']);
 
         return $result;

--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -5,7 +5,7 @@
  * Time: 下午 17:07
  */
 
-namespace SummerGeorge\AliOSS;
+namespace Jacobcyl\AliOSS;
 
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\AdapterInterface;

--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -5,7 +5,7 @@
  * Time: 下午 17:07
  */
 
-namespace Jacobcyl\AliOSS;
+namespace SummerGeorge\AliOSS;
 
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\AdapterInterface;

--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -573,6 +573,33 @@ class AliOssAdapter extends AbstractAdapter
         if (!$this->has($path)) throw new FileNotFoundException($path.' not found');
         return ( $this->ssl ? 'https://' : 'http://' ) . ( $this->isCname ? ( $this->cdnDomain == '' ? $this->endPoint : $this->cdnDomain ) : $this->bucket . '.' . $this->endPoint ) . '/' . ltrim($path, '/');
     }
+    
+    
+    /**
+     * @param $path
+     * @param $expire
+     * @param $options
+     * @return string
+     * @throws FileNotFoundException
+     * @throws OssException
+     */
+    public function getTemporaryUrl($path, $expire, $options) {
+        if (!$this->has($path))
+            throw new FileNotFoundException($path.' not found');
+        $method = OssClient::OSS_HTTP_GET;
+        if (Arr::has($options, OssClient::OSS_METHOD)) {
+            $method = $options['method'];
+        }
+        return $this->getClient()
+            ->signUrl(
+                $this->getBucket(),
+                $path,
+                now()->diffInSeconds($expire),
+                $method,
+                $options
+            );
+    }
+    
 
     /**
      * The the ACL visibility.

--- a/src/AliOssServiceProvider.php
+++ b/src/AliOssServiceProvider.php
@@ -5,6 +5,7 @@ namespace Jacobcyl\AliOSS;
 use Jacobcyl\AliOSS\Plugins\PutFile;
 use Jacobcyl\AliOSS\Plugins\PutRemoteFile;
 use Jacobcyl\AliOSS\Plugins\SignUrl;
+use Jacobcyl\AliOSS\Plugins\GetProcessUrl;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
@@ -37,13 +38,13 @@ class AliOssServiceProvider extends ServiceProvider
 
             $cdnDomain = empty($config['cdnDomain']) ? '' : $config['cdnDomain'];
             $bucket    = $config['bucket'];
-            $ssl       = empty($config['ssl']) ? false : $config['ssl']; 
+            $ssl       = empty($config['ssl']) ? false : $config['ssl'];
             $isCname   = empty($config['isCName']) ? false : $config['isCName'];
             $debug     = empty($config['debug']) ? false : $config['debug'];
 
             $endPoint  = $config['endpoint']; // 默认作为外部节点
             $epInternal= $isCname?$cdnDomain:(empty($config['endpoint_internal']) ? $endPoint : $config['endpoint_internal']); // 内部节点
-            
+
             if($debug) Log::debug('OSS config:', $config);
 
             $client  = new OssClient($accessId, $accessKey, $epInternal, $isCname);
@@ -51,11 +52,14 @@ class AliOssServiceProvider extends ServiceProvider
 
             //Log::debug($client);
             $filesystem =  new Filesystem($adapter);
-            
+
             $filesystem->addPlugin(new PutFile());
             $filesystem->addPlugin(new PutRemoteFile());
-            // 增加使用签名URL进行临时授权
+            //增加使用签名URL进行临时授权
             $filesystem->addPlugin(new SignUrl());
+
+            //增加图片处理的方法
+            $filesystem->addPlugin(new GetProcessUrl());
             //$filesystem->addPlugin(new CallBack());
             return $filesystem;
         });

--- a/src/AliOssServiceProvider.php
+++ b/src/AliOssServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SummerGeorge\AliOSS;
+namespace Jacobcyl\AliOSS;
 
-use SummerGeorge\AliOSS\Plugins\PutFile;
-use SummerGeorge\AliOSS\Plugins\PutRemoteFile;
-use SummerGeorge\AliOSS\Plugins\SignUrl;
+use Jacobcyl\AliOSS\Plugins\PutFile;
+use Jacobcyl\AliOSS\Plugins\PutRemoteFile;
+use Jacobcyl\AliOSS\Plugins\SignUrl;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;

--- a/src/AliOssServiceProvider.php
+++ b/src/AliOssServiceProvider.php
@@ -4,6 +4,7 @@ namespace Jacobcyl\AliOSS;
 
 use Jacobcyl\AliOSS\Plugins\PutFile;
 use Jacobcyl\AliOSS\Plugins\PutRemoteFile;
+use Jacobcyl\AliOSS\Plugins\SignUrl;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;

--- a/src/AliOssServiceProvider.php
+++ b/src/AliOssServiceProvider.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Jacobcyl\AliOSS;
+namespace SummerGeorge\AliOSS;
 
-use Jacobcyl\AliOSS\Plugins\PutFile;
-use Jacobcyl\AliOSS\Plugins\PutRemoteFile;
-use Jacobcyl\AliOSS\Plugins\SignUrl;
+use SummerGeorge\AliOSS\Plugins\PutFile;
+use SummerGeorge\AliOSS\Plugins\PutRemoteFile;
+use SummerGeorge\AliOSS\Plugins\SignUrl;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;

--- a/src/AliOssServiceProvider.php
+++ b/src/AliOssServiceProvider.php
@@ -40,6 +40,7 @@ class AliOssServiceProvider extends ServiceProvider
             $bucket    = $config['bucket'];
             $ssl       = empty($config['ssl']) ? false : $config['ssl'];
             $isCname   = empty($config['isCName']) ? false : $config['isCName'];
+            $securityToken = empty($config['securityToken']) ? '' : $config['securityToken'];
             $debug     = empty($config['debug']) ? false : $config['debug'];
 
             $endPoint  = $config['endpoint']; // 默认作为外部节点
@@ -47,7 +48,7 @@ class AliOssServiceProvider extends ServiceProvider
 
             if($debug) Log::debug('OSS config:', $config);
 
-            $client  = new OssClient($accessId, $accessKey, $epInternal, $isCname);
+            $client  = new OssClient($accessId, $accessKey, $epInternal, $isCname, $securityToken);
             $adapter = new AliOssAdapter($client, $bucket, $endPoint, $ssl, $isCname, $debug, $cdnDomain);
 
             //Log::debug($client);

--- a/src/AliOssServiceProvider.php
+++ b/src/AliOssServiceProvider.php
@@ -40,7 +40,7 @@ class AliOssServiceProvider extends ServiceProvider
             $bucket    = $config['bucket'];
             $ssl       = empty($config['ssl']) ? false : $config['ssl'];
             $isCname   = empty($config['isCName']) ? false : $config['isCName'];
-            $securityToken = empty($config['securityToken']) ? '' : $config['securityToken'];
+            $securityToken = empty($config['securityToken']) ? null : $config['securityToken'];
             $debug     = empty($config['debug']) ? false : $config['debug'];
 
             $endPoint  = $config['endpoint']; // 默认作为外部节点

--- a/src/AliOssServiceProvider.php
+++ b/src/AliOssServiceProvider.php
@@ -44,8 +44,9 @@ class AliOssServiceProvider extends ServiceProvider
             $debug     = empty($config['debug']) ? false : $config['debug'];
 
             $endPoint  = $config['endpoint']; // 默认作为外部节点
-            $epInternal= $isCname?$cdnDomain:(empty($config['endpoint_internal']) ? $endPoint : $config['endpoint_internal']); // 内部节点
-
+            // $epInternal= $isCname?$cdnDomain:(empty($config['endpoint_internal']) ? $endPoint : $config['endpoint_internal']); // 内部节点
+            $epInternal= (empty($config['endpoint_internal']) ? $endPoint : $config['endpoint_internal']); // 内部节点
+            
             if($debug) Log::debug('OSS config:', $config);
 
             $client  = new OssClient($accessId, $accessKey, $epInternal, $isCname, $securityToken);

--- a/src/AliOssServiceProvider.php
+++ b/src/AliOssServiceProvider.php
@@ -53,6 +53,8 @@ class AliOssServiceProvider extends ServiceProvider
             
             $filesystem->addPlugin(new PutFile());
             $filesystem->addPlugin(new PutRemoteFile());
+            // 增加使用签名URL进行临时授权
+            $filesystem->addPlugin(new SignUrl());
             //$filesystem->addPlugin(new CallBack());
             return $filesystem;
         });

--- a/src/Plugins/GetProcessUrl.php
+++ b/src/Plugins/GetProcessUrl.php
@@ -21,7 +21,7 @@ class GetProcessUrl extends AbstractPlugin
      */
     public function getMethod()
     {
-        return 'signUrl';
+        return 'getProcessUrl';
     }
 
     /**

--- a/src/Plugins/GetProcessUrl.php
+++ b/src/Plugins/GetProcessUrl.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Created by summer.
+ * User: summer
+ * Date: 18/7/22
+ * Time: 下午7:03
+ */
+
+namespace Jacobcyl\AliOSS\Plugins;
+
+use League\Flysystem\Plugin\AbstractPlugin;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+
+class GetProcessUrl extends AbstractPlugin
+{
+
+    /**
+     * Get the method name.
+     *
+     * @return string
+     */
+    public function getMethod()
+    {
+        return 'signUrl';
+    }
+
+    /**
+     * 对oss图片进行操作
+     * 阿里云 oss 帮助文档：https://help.aliyun.com/document_detail/44688.html?spm=a2c4g.11186623.6.1199.40572e934MoHWu
+     * @param $path 文件路径
+     * @param string $action 操作名称
+     * @param array $option 操作参数
+     * @return string 返回 url 链接地址
+     * @throws \Exception
+     */
+    public function handle($path, $action = 'resize', $option = ['m' => 'fixed','h' => '100','w' => '100']){
+        if(empty($action) || empty($option)){
+            throw new \Exception('操作名称和操作参数不能为空！');
+        }
+
+        $url = $this->filesystem->getAdapter()->getUrl($path);
+
+        $param = '';
+        foreach ($option as $key => $value){
+            $param .= ','.$key.'_'.$value;
+        }
+
+        return $url.'?x-oss-process=image/'.$action.$param;
+    }
+}

--- a/src/Plugins/PutFile.php
+++ b/src/Plugins/PutFile.php
@@ -8,7 +8,6 @@
 
 namespace Jacobcyl\AliOSS\Plugins;
 
-use Illuminate\Support\Facades\Log;
 use League\Flysystem\Config;
 use League\Flysystem\Plugin\AbstractPlugin;
 
@@ -30,7 +29,7 @@ class PutFile extends AbstractPlugin
         if (method_exists($this->filesystem, 'getConfig')) {
             $config->setFallback($this->filesystem->getConfig());
         }
-        
+
         return (bool)$this->filesystem->getAdapter()->writeFile($path, $filePath, $config);
     }
 }

--- a/src/Plugins/PutFile.php
+++ b/src/Plugins/PutFile.php
@@ -6,7 +6,7 @@
  * Time: 下午8:31
  */
 
-namespace SummerGeorge\AliOSS\Plugins;
+namespace Jacobcyl\AliOSS\Plugins;
 
 use League\Flysystem\Config;
 use League\Flysystem\Plugin\AbstractPlugin;

--- a/src/Plugins/PutFile.php
+++ b/src/Plugins/PutFile.php
@@ -6,7 +6,7 @@
  * Time: 下午8:31
  */
 
-namespace Jacobcyl\AliOSS\Plugins;
+namespace SummerGeorge\AliOSS\Plugins;
 
 use League\Flysystem\Config;
 use League\Flysystem\Plugin\AbstractPlugin;

--- a/src/Plugins/PutRemoteFile.php
+++ b/src/Plugins/PutRemoteFile.php
@@ -5,7 +5,7 @@
  * Date: 16/5/20
  * Time: 下午8:31
  */
-namespace Jacobcyl\AliOSS\Plugins;
+namespace SummerGeorge\AliOSS\Plugins;
 use League\Flysystem\Config;
 use League\Flysystem\Plugin\AbstractPlugin;
 class PutRemoteFile extends AbstractPlugin

--- a/src/Plugins/PutRemoteFile.php
+++ b/src/Plugins/PutRemoteFile.php
@@ -5,7 +5,7 @@
  * Date: 16/5/20
  * Time: 下午8:31
  */
-namespace SummerGeorge\AliOSS\Plugins;
+namespace Jacobcyl\AliOSS\Plugins;
 use League\Flysystem\Config;
 use League\Flysystem\Plugin\AbstractPlugin;
 class PutRemoteFile extends AbstractPlugin

--- a/src/Plugins/SignUrl.php
+++ b/src/Plugins/SignUrl.php
@@ -8,10 +8,8 @@
 
 namespace Jacobcyl\AliOSS\Plugins;
 
-use Symfony\Component\Filesystem\Exception\FileNotFoundException;
-use Illuminate\Support\Facades\Log;
-use League\Flysystem\Config;
 use League\Flysystem\Plugin\AbstractPlugin;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class SignUrl extends AbstractPlugin
 {
@@ -27,7 +25,7 @@ class SignUrl extends AbstractPlugin
     }
 
     public function handle($path, $timeout = 600){
-        if (!$this->filesystem->getAdapter()->has($path)) throw new FileNotFoundException($filePath.' not found');
+        if (!$this->filesystem->getAdapter()->has($path)) throw new FileNotFoundException($path.' not found');
         return $this->filesystem->getAdapter()->getClient()->signUrl($this->filesystem->getAdapter()->getBucket(),$path,$timeout);
     }
 }

--- a/src/Plugins/SignUrl.php
+++ b/src/Plugins/SignUrl.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Created by summer.
+ * User: summer
+ * Date: 18/7/22
+ * Time: 下午7:03
+ */
+
+namespace Jacobcyl\AliOSS\Plugins;
+
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
+use Illuminate\Support\Facades\Log;
+use League\Flysystem\Config;
+use League\Flysystem\Plugin\AbstractPlugin;
+
+class SignUrl extends AbstractPlugin
+{
+
+    /**
+     * Get the method name.
+     *
+     * @return string
+     */
+    public function getMethod()
+    {
+        return 'signUrl';
+    }
+
+    public function handle($path, $timeout = 600){
+        if (!$this->filesystem->getAdapter()->has($path)) throw new FileNotFoundException($filePath.' not found');
+        return $this->filesystem->getAdapter()->getClient()->signUrl($this->filesystem->getAdapter()->getBucket(),$path,$timeout);
+    }
+}

--- a/src/Plugins/SignUrl.php
+++ b/src/Plugins/SignUrl.php
@@ -6,7 +6,7 @@
  * Time: 下午7:03
  */
 
-namespace SummerGeorge\AliOSS\Plugins;
+namespace Jacobcyl\AliOSS\Plugins;
 
 use League\Flysystem\Plugin\AbstractPlugin;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;

--- a/src/Plugins/SignUrl.php
+++ b/src/Plugins/SignUrl.php
@@ -6,7 +6,7 @@
  * Time: 下午7:03
  */
 
-namespace Jacobcyl\AliOSS\Plugins;
+namespace SummerGeorge\AliOSS\Plugins;
 
 use League\Flysystem\Plugin\AbstractPlugin;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;


### PR DESCRIPTION
对aliyuncs/oss-sdk-php中的signUrl进行适配，支持获取私有Bucket对象临时访问url。

使用方式：
```
Storage::disk('oss')->signUrl('path/to/img.jpg',600)
```