### PR TITLE
ReadStream wrap to stream if string returned

### DIFF
--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -449,10 +449,15 @@ class AliOssAdapter extends AbstractAdapter
     public function readStream($path)
     {
         $result = $this->readObject($path);
-        $result['stream'] = $result['raw_contents'];
+        if (is_resource($result['raw_contents'])) {
+            $result['stream'] = $result['raw_contents'];
+            // Ensure the EntityBody object destruction doesn't close the stream
+            $result['raw_contents']->detachStream();
+        } else {
+            $result['stream'] = fopen('php://temp', 'r+');
+            fwrite($result['stream'], $result['raw_contents']);
+        }
         rewind($result['stream']);
-        // Ensure the EntityBody object destruction doesn't close the stream
-        $result['raw_contents']->detachStream();
         unset($result['raw_contents']);
 
         return $result;


### PR DESCRIPTION
This pull request intoduces solution like this PR
https://github.com/jacobcyl/Aliyun-oss-storage/pull/50
but with another implemented code.
Problem if $result['raw_contents'] contains string instead of resource