### PR TITLE
Fix bugs that are not resources 'ReadStream' in AliOssAdapter.php

### DIFF
--- a/src/AliOssAdapter.php
+++ b/src/AliOssAdapter.php
@@ -449,10 +449,15 @@ class AliOssAdapter extends AbstractAdapter
     public function readStream($path)
     {
         $result = $this->readObject($path);
-        $result['stream'] = $result['raw_contents'];
+        if (is_resource($result['raw_contents'])) {
+            $result['stream'] = $result['raw_contents'];
+            // Ensure the EntityBody object destruction doesn't close the stream
+            $result['raw_contents']->detachStream();
+        } else {
+            $result['stream'] = fopen('php://temp', 'r+');
+            fwrite($result['stream'], $result['raw_contents']);
+        }
         rewind($result['stream']);
-        // Ensure the EntityBody object destruction doesn't close the stream
-        $result['raw_contents']->detachStream();
         unset($result['raw_contents']);
 
         return $result;


### PR DESCRIPTION
There is a method bug in line 449in file  ‘src/AliOssAdapter.php’.When I want to download the resource, the resource file type is judged incorrectly and should be compatible with the processing of the string.